### PR TITLE
Add client management

### DIFF
--- a/iugu.gemspec
+++ b/iugu.gemspec
@@ -19,10 +19,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-nav'
 end

--- a/lib/iugu.rb
+++ b/lib/iugu.rb
@@ -18,6 +18,7 @@ require_relative 'iugu/invoice'
 require_relative 'iugu/subscription'
 require_relative 'iugu/charge'
 require_relative 'iugu/plan'
+require_relative 'iugu/client'
 
 module Iugu
   class AuthenticationException < StandardError

--- a/lib/iugu/api_create.rb
+++ b/lib/iugu/api_create.rb
@@ -1,21 +1,12 @@
 module Iugu
   module APICreate
-    module ClassMethods
-      def create(attributes = {})
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('POST',
-                                                              self.url(attributes),
-                                                              attributes))
-      rescue Iugu::RequestWithErrors => ex
-        obj = self.new
-        obj.set_attributes attributes, true
-        obj.errors = ex.errors
-        obj
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def create(attributes = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', self.class.url(attributes), attributes))
+    rescue Iugu::RequestWithErrors => ex
+      obj = self.class.new
+      obj.set_attributes attributes, true
+      obj.errors = ex.errors
+      obj
     end
   end
 end

--- a/lib/iugu/api_delete.rb
+++ b/lib/iugu/api_delete.rb
@@ -1,7 +1,7 @@
 module Iugu
   module APIDelete
     def delete
-      APIRequest.request('DELETE', self.class.url(self.attributes))
+      APIRequest.request(self, 'DELETE', self.class.url(self.attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_fetch.rb
+++ b/lib/iugu/api_fetch.rb
@@ -1,9 +1,7 @@
 module Iugu
   module APIFetch
     def refresh
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('GET',
-                                                                 self.class.url(self.id)))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', self.class.url(self.id)))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -11,16 +9,8 @@ module Iugu
       false
     end
 
-    module ClassMethods
-      def fetch(options = nil)
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('GET',
-                                                              self.url(options)))
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def fetch(options = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', self.class.url(options)))
     end
   end
 end

--- a/lib/iugu/api_save.rb
+++ b/lib/iugu/api_save.rb
@@ -2,10 +2,8 @@ module Iugu
   module APISave
     def save
       method = is_new? ? 'POST' : 'PUT'
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request(method,
-                                                                 self.class.url(self.attributes),
-                                                                 modified_attributes))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, method, self.class.url(self.attributes),
+                                                                       modified_attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_search.rb
+++ b/lib/iugu/api_search.rb
@@ -1,13 +1,7 @@
 module Iugu
   module APICreate
-    module ClassMethods
-      def search(options = {})
-        Iugu::Factory.create_from_response self.object_type, APIRequest.request("GET", self.url(options), options)
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def search(options = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, "GET", self.class.url(options), options))
     end
   end
 end

--- a/lib/iugu/charge.rb
+++ b/lib/iugu/charge.rb
@@ -8,7 +8,7 @@ module Iugu
 
     def invoice
       return false unless @attributes['invoice_id']
-      Invoice.fetch @attributes['invoice_id']
+      Invoice.new(options: self.options).fetch(@attributes['invoice_id'])
     end
   end
 end

--- a/lib/iugu/client.rb
+++ b/lib/iugu/client.rb
@@ -1,0 +1,42 @@
+
+module Iugu
+  class Client
+    def initialize(api_key:)
+      @api_key = api_key
+    end
+
+    def charge
+      Iugu::Charge.new(options)
+    end
+
+    def customer
+      Iugu::Customer.new(options)
+    end
+
+    def invoice
+      Iugu::Invoice.new(options)
+    end
+
+    def payment_method
+      Iugu::PaymentMethod.new(options)
+    end
+
+    def payment_token
+      Iugu::PaymentToken.new(options)
+    end
+
+    def subscription
+      Iugu::Subscription.new(options)
+    end
+
+    def plan
+      Iugu::Plan.new(options)
+    end
+
+    private
+
+    def options
+      { options: { api_key: @api_key } }
+    end
+  end
+end

--- a/lib/iugu/customer.rb
+++ b/lib/iugu/customer.rb
@@ -6,16 +6,16 @@ module Iugu
     include Iugu::APIDelete
 
     def payment_methods
-      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod)
+      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod.new(options: self.options))
     end
 
     def invoices
-      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice)
+      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice.new(options: self.options))
     end
 
     def default_payment_method
       return false unless @attributes['default_payment_method_id']
-      PaymentMethod.fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id })
+      PaymentMethod.new(options: self.options).fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id })
     end
   end
 end

--- a/lib/iugu/factory.rb
+++ b/lib/iugu/factory.rb
@@ -1,6 +1,9 @@
 module Iugu
   class Factory
-    def self.create_from_response(object_type, response, errors = nil)
+    def self.create_from_response(object, response, errors = nil)
+      object_type = object.class.object_type
+      options = object.options
+
       if response.nil?
         obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new
         obj.errors = errors if errors
@@ -8,17 +11,17 @@ module Iugu
       elsif response.is_a?(Array)
         results = []
         response.each do |i|
-          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new i
+          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new(attributes: i, options: options)
         end
         Iugu::SearchResult.new results, results.count
       elsif response['items'] && response['totalItems']
         results = []
         response['items'].each do |v|
-          results.push self.create_from_response(object_type, v)
+          results.push self.create_from_response(object, v)
         end
         Iugu::SearchResult.new results, response['totalItems']
       else
-        Iugu.const_get(Iugu::Utils.camelize(object_type)).new response
+        Iugu.const_get(Iugu::Utils.camelize(object_type)).new(attributes: response, options: options)
       end
     end
   end

--- a/lib/iugu/invoice.rb
+++ b/lib/iugu/invoice.rb
@@ -7,13 +7,11 @@ module Iugu
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.new(options: self.options).fetch(@attributes['customer_id'])
     end
 
     def cancel
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/cancel"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT', "#{self.class.url(self.id)}/cancel"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -22,9 +20,7 @@ module Iugu
     end
 
     def refund
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/refund"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', "#{self.class.url(self.id)}/refund"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -33,10 +29,7 @@ module Iugu
     end
 
     def duplicate(attributes = {})
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/duplicate",
-                                                                 attributes ))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', "#{self.class.url(self.id)}/duplicate", attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/object.rb
+++ b/lib/iugu/object.rb
@@ -3,12 +3,13 @@ require 'set'
 module Iugu
   class Object
 
-    attr_accessor :errors
+    attr_accessor :errors, :options
 
     undef :id if method_defined?(:id)
 
-    def initialize(attributes = {})
+    def initialize(attributes: {}, options: {})
       @unsaved_attributes = Set.new
+      @options = options
       set_attributes attributes
     end
 
@@ -53,6 +54,13 @@ module Iugu
         add_accessor(k)
       end
       @unsaved_attributes = @attributes.keys.to_set if unsaved
+    end
+
+    def api_key
+      @api_key ||=
+        begin
+          options[:api_key] || Iugu.api_key || Utils.auth_from_env
+        end
     end
 
     protected

--- a/lib/iugu/plan.rb
+++ b/lib/iugu/plan.rb
@@ -5,10 +5,8 @@ module Iugu
     include Iugu::APISave
     include Iugu::APIDelete
 
-    def self.fetch_by_identifier(identifier)
-      Iugu::Factory.create_from_response(object_type,
-                                         APIRequest.request('GET',
-                                                            "#{url}/identifier/#{identifier}"))
+    def fetch_by_identifier(identifier)
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', "#{url}/identifier/#{identifier}"))
     end
   end
 end

--- a/lib/iugu/search_result.rb
+++ b/lib/iugu/search_result.rb
@@ -12,5 +12,7 @@ module Iugu
     def results
       @results
     end
+
+    alias_method :count, :total
   end
 end

--- a/lib/iugu/subscription.rb
+++ b/lib/iugu/subscription.rb
@@ -6,10 +6,9 @@ module Iugu
     include Iugu::APIDelete
 
     def add_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/add_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT',
+                                                                       "#{self.class.url(self.id)}/add_credits",
+                                                                       { quantity: quantity }))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -18,10 +17,9 @@ module Iugu
     end
 
     def remove_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/remove_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT',
+                                                                       "#{self.class.url(self.id)}/remove_credits",
+                                                                       { quantity: quantity }))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -30,9 +28,8 @@ module Iugu
     end
 
     def suspend
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/suspend"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/suspend"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -41,9 +38,8 @@ module Iugu
     end
 
     def activate
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/activate"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/activate"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -53,10 +49,9 @@ module Iugu
 
     def change_plan(plan_identifier, options = {})
       options.merge!({ plan_identifier: plan_identifier })
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/change_plan",
-                                                                 options))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/change_plan",
+                                                                       options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -66,15 +61,14 @@ module Iugu
 
     def change_plan_simulation(plan_identifier, options = {})
       options.merge!({ plan_identifier: plan_identifier })
-      Iugu::Factory.create_from_response(self.class.object_type,
-                                         APIRequest.request('GET',
-                                                            "#{self.class.url(self.id)}/change_plan_simulation",
-                                                            options))
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET',
+                                                                  "#{self.class.url(self.id)}/change_plan_simulation",
+                                                                  options))
     end
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.new(options: self.options).fetch(@attributes['customer_id'])
     end
   end
 end


### PR DESCRIPTION
This commit will apply a massive change by adding the possibility
to add more than one api_token to handle more than one account.
So if you have multiple accounts using the Gateway, with this changing
you will possible to handle it easily by configuring the client as
follows:

```
client = Iugu::Client.new(api_token: xxx)
client.invoice.fetch
client.customer.fetch
...
```
This changing is heavily inpisred by The Twitter Ruby Gem