### PR TITLE
Correção na geração do cabeçalho de autorização

### DIFF
--- a/lib/iugu/api_request.rb
+++ b/lib/iugu/api_request.rb
@@ -43,12 +43,11 @@ module Iugu
 
     def self.default_headers
       {
-        authorization: 'Basic ' + Base64.encode64(Iugu.api_key + ':'),
+        authorization: 'Basic ' + Base64.strict_encode64(Iugu.api_key + ':'),
         accept: 'application/json',
         accept_charset: 'utf-8',
         user_agent: 'Iugu RubyLibrary',
         accept_language: 'pt-br;q=0.9,pt-BR',
-        #content_type: 'application/x-www-form-urlencoded; charset=utf-8'
         content_type: 'application/json; charset=utf-8'
       }
     end

--- a/lib/iugu/version.rb
+++ b/lib/iugu/version.rb
@@ -1,3 +1,3 @@
 module Iugu
-  VERSION = '1.0.9'
+  VERSION = '1.0.10'
 end


### PR DESCRIPTION
Efetuado correção na geração do cabeçalho de autorização, pois o Base64.encode64 insere automaticamente o \n a cada 60 caracteres e neste caso não era o comportamento esperado.