### PR TITLE
Remove \n on header to avoid CR/LF error

### DIFF
--- a/lib/iugu/api_request.rb
+++ b/lib/iugu/api_request.rb
@@ -43,7 +43,7 @@ module Iugu
 
     def self.default_headers
       {
-        authorization: 'Basic ' + Base64.strict_encode64(Iugu.api_key + ':'),
+        authorization: 'Basic ' + Base64.strict_encode64(Iugu.api_key + ':').gsub("\n", ""),
         accept: 'application/json',
         accept_charset: 'utf-8',
         user_agent: 'Iugu RubyLibrary',

--- a/lib/iugu/version.rb
+++ b/lib/iugu/version.rb
@@ -1,3 +1,3 @@
 module Iugu
-  VERSION = '1.0.10'
+  VERSION = '1.0.11'
 end


### PR DESCRIPTION
**Problem** 

![Captura de tela de 2021-08-13 15-34-22](https://user-images.githubusercontent.com/24974469/129407456-66d08a3a-0a3c-4dc5-85c6-6870e2a49ffe.png)

Using the new iugu api key, the `default_headers` method was adding `\n` in the `authorization`, resulting in `CR/LF error`

```
ArgumentError: header field value cannot include CR/LF
```

**Solution** 

![Captura de tela de 2021-08-13 15-52-40](https://user-images.githubusercontent.com/24974469/129407781-b3bccd76-ce3b-4c86-b6c2-363300939af9.png)

Removing the `\n`, the request worked as expected 
